### PR TITLE
Revert "Hotfix -> congnitive bitmap issues (android)"

### DIFF
--- a/microsoft-cognitive-services/Android.md
+++ b/microsoft-cognitive-services/Android.md
@@ -187,13 +187,19 @@ public class MainActivity : Activity
             //Get the bitmap with the right rotation
             _bitmap = BitmapHelpers.GetAndRotateBitmap(_file.Path);
 
+            //Resize the picture to be under 4MB (Emotion API limitation and better for Android memory)
+            _bitmap = Bitmap.CreateScaledBitmap(_bitmap, 2000, (int)(2000*_bitmap.Height/_bitmap.Width), false);
+
             //Display the image
             _imageView.SetImageBitmap(_bitmap);
+
+            //Loading message
+            _resultTextView.Text = "Loading...";
 
             using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
             {
                 //Get a stream
-                _bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
+                _bitmap.Compress(Bitmap.CompressFormat.Jpeg, 90, stream);
                 stream.Seek(0, System.IO.SeekOrigin.Begin);
 
                 //Get and display the happiness score

--- a/microsoft-cognitive-services/solutions/AndroidApp/BitmapHelper.cs
+++ b/microsoft-cognitive-services/solutions/AndroidApp/BitmapHelper.cs
@@ -3,47 +3,51 @@ using Android.Media;
 
 namespace AndroidApp
 {
-	public static class BitmapHelpers
-	{
-		public static Bitmap GetAndRotateBitmap (string fileName)
-		{
-			Bitmap bitmap = BitmapFactory.DecodeFile (fileName);
+    public static class BitmapHelpers
+    {
+        public static Bitmap GetAndRotateBitmap(string fileName)
+        {
+            Bitmap bitmap = BitmapFactory.DecodeFile(fileName);
 
+            // Images are being saved in landscape, so rotate them back to portrait if they were taken in portrait
+            // See https://forums.xamarin.com/discussion/5409/photo-being-saved-in-landscape-not-portrait
+            // See http://developer.android.com/reference/android/media/ExifInterface.html
+            using (Matrix mtx = new Matrix())
+            {
+                if (Android.OS.Build.Product.Contains("Emulator"))
+                {
+                    mtx.PreRotate(90);
+                }
+                else
+                {
+                    ExifInterface exif = new ExifInterface(fileName);
+                    var orientation = (Orientation)exif.GetAttributeInt(ExifInterface.TagOrientation, (int)Orientation.Normal);
 
-			// Images are being saved in landscape, so rotate them back to portrait if they were taken in portrait
-			// See https://forums.xamarin.com/discussion/5409/photo-being-saved-in-landscape-not-portrait
-			// See http://developer.android.com/reference/android/media/ExifInterface.html
-			using (var mtx = new Matrix ()) {
-				if (Android.OS.Build.Product.Contains ("Emulator")) {
-					mtx.PreRotate (90);
-				} else {
-					var exif = new ExifInterface (fileName);
-					var orientation = (Orientation)exif.GetAttributeInt (ExifInterface.TagOrientation, (int)Orientation.Normal);
+                    //TODO : handle FlipHorizontal, FlipVertical, Transpose and Transverse
+                    switch (orientation)
+                    {
+                        case Orientation.Rotate90:
+                            mtx.PreRotate(90);
+                            break;
+                        case Orientation.Rotate180:
+                            mtx.PreRotate(180);
+                            break;
+                        case Orientation.Rotate270:
+                            mtx.PreRotate(270);
+                            break;
+                        case Orientation.Normal:
+                            // Normal, do nothing
+                            break;
+                        default:
+                            break;
+                    }
+                }
 
-					//TODO : handle FlipHorizontal, FlipVertical, Transpose and Transverse
-					switch (orientation) {
-					case Orientation.Rotate90:
-						mtx.PreRotate (90);
-						break;
-					case Orientation.Rotate180:
-						mtx.PreRotate (180);
-						break;
-					case Orientation.Rotate270:
-						mtx.PreRotate (270);
-						break;
-					case Orientation.Undefined:
-					case Orientation.Normal:
-						// Normal, do nothing
-						break;
-					}
+                if (mtx != null)
+                    bitmap = Bitmap.CreateBitmap(bitmap, 0, 0, bitmap.Width, bitmap.Height, mtx, false);
+            }
 
-					if (mtx != null)
-						bitmap = Bitmap.CreateBitmap (bitmap, 0, 0, bitmap.Width, bitmap.Height, mtx, false);
-				}
-
-				return bitmap;
-			}
-		}
-	}
+            return bitmap;
+        }
+    }
 }
-

--- a/microsoft-cognitive-services/solutions/AndroidApp/MainActivity.cs
+++ b/microsoft-cognitive-services/solutions/AndroidApp/MainActivity.cs
@@ -93,14 +93,17 @@ namespace AndroidApp
             {
                 //Get the bitmap with the right rotation
                 _bitmap = BitmapHelpers.GetAndRotateBitmap(_file.Path);
-                
+
+                //Resize the picture to be under 4MB (Emotion API limitation and better for Android memory)
+                _bitmap = Bitmap.CreateScaledBitmap(_bitmap, 2000, (int)(2000*_bitmap.Height/_bitmap.Width), false);
+
                 //Display the image
                 _imageView.SetImageBitmap(_bitmap);
                 
                 using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
                 {
                     //Get a stream
-                    _bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
+                    _bitmap.Compress(Bitmap.CompressFormat.Jpeg, 90, stream);
                     stream.Seek(0, System.IO.SeekOrigin.Begin);
 
                     //Get and display the happiness score

--- a/microsoft-cognitive-services/solutions/AndroidApp/MainActivity.cs
+++ b/microsoft-cognitive-services/solutions/AndroidApp/MainActivity.cs
@@ -100,8 +100,7 @@ namespace AndroidApp
                 using (System.IO.MemoryStream stream = new System.IO.MemoryStream())
                 {
                     //Get a stream
-					//lower quality for request.
-                    _bitmap.Compress(Bitmap.CompressFormat.Jpeg, 50, stream);
+                    _bitmap.Compress(Bitmap.CompressFormat.Jpeg, 100, stream);
                     stream.Seek(0, System.IO.SeekOrigin.Begin);
 
                     //Get and display the happiness score


### PR DESCRIPTION
Orientation has already been fixed by PR https://github.com/xamarin/mini-hacks/pull/18
I've done a better version of resizing (resizing first and compressing) in b82a434